### PR TITLE
Restore custom entries in tpot.yml after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - **Improve install speed with apt-fast**
   - Migrating from a stable base install to Debian (Sid) requires downloading lots of packages. Depending on your geo location the download speed was already improved by introducing netselect-apt to determine the fastest mirror. With apt-fast the downloads will be even faster by downloading packages not only in parallel but also with multiple connections per package.
   
-## 20190416
+## 20190417
 - **Reapply custom HPFEED settings after update**
   - The `/opt/tpot/update.sh` script overwrites all local changes in `/opt/tpot/etc/tpot.yml`
   - After pulling the latest files from GitHub, check in our backup whether the HPFEED settings were enabled before
   - If they were enabled, the old HPFEED settings are extracted and reapplied to our new tpot.yml
+- **Reapply custom ews.cfg volume mount after update**
+  - Check in our backup whether we had a custom ews.cfg volume mount before.
+  - If we had one, reapply it to our new tpot.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,9 @@
   - If T-Pot, opposed to the requirements, does not have full internet access netselect-apt fails to determine the fastest mirror as it needs ICMP and UDP outgoing. Should netselect-apt fail the default mirrors will be used.
 - **Improve install speed with apt-fast**
   - Migrating from a stable base install to Debian (Sid) requires downloading lots of packages. Depending on your geo location the download speed was already improved by introducing netselect-apt to determine the fastest mirror. With apt-fast the downloads will be even faster by downloading packages not only in parallel but also with multiple connections per package.
+  
+## 20190416
+- **Reapply custom HPFEED settings after update**
+  - The `/opt/tpot/update.sh` script overwrites all local changes in `/opt/tpot/etc/tpot.yml`
+  - After pulling the latest files from GitHub, check in our backup whether the HPFEED settings were enabled before
+  - If they were enabled, the old HPFEED settings are extracted and reapplied to our new tpot.yml

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Furthermore we use the following tools
 - **Improve install speed with apt-fast**
   - Migrating from a stable base install to Debian (Sid) requires downloading lots of packages. Depending on your geo location the download speed was already improved by introducing netselect-apt to determine the fastest mirror. Wit
 h apt-fast the downloads will be even faster by downloading packages not only in parallel but also with multiple connections per package.
+- **Reapply custom HPFEED settings after update**
+  - The `/opt/tpot/update.sh` script overwrites all local changes in `/opt/tpot/etc/tpot.yml`
+  - After pulling the latest files from GitHub, check in our backup whether the HPFEED settings were enabled before
+  - If they were enabled, the old HPFEED settings are extracted and reapplied to our new tpot.yml
 
 <a name="concept"></a>
 # Technical Concept
@@ -361,6 +365,7 @@ For the ones of you who want to live on the bleeding edge of T-Pot development w
  - upgrade the system to the packages available in Debian (Sid)
  - update all resources to be in-sync with the T-Pot master branch
  - ensure all T-Pot relevant system files will be patched / copied into the original T-Pot state
+ - restore your custom HPFEED settings from the backup
 
 You simply run the update script:
 ```

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ h apt-fast the downloads will be even faster by downloading packages not only in
   - The `/opt/tpot/update.sh` script overwrites all local changes in `/opt/tpot/etc/tpot.yml`
   - After pulling the latest files from GitHub, check in our backup whether the HPFEED settings were enabled before
   - If they were enabled, the old HPFEED settings are extracted and reapplied to our new tpot.yml
+- **Reapply custom ews.cfg volume mount after update**
+  - Check in our backup whether we had a custom ews.cfg volume mount before.
+  - If we had one, reapply it to our new tpot.yml
 
 <a name="concept"></a>
 # Technical Concept

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ For the ones of you who want to live on the bleeding edge of T-Pot development w
  - upgrade the system to the packages available in Debian (Sid)
  - update all resources to be in-sync with the T-Pot master branch
  - ensure all T-Pot relevant system files will be patched / copied into the original T-Pot state
- - restore your custom HPFEED settings from the backup
+ - restore your custom HPFEED settings and the volume for our custom ews.cfg from the backup
 
 You simply run the update script:
 ```

--- a/update.sh
+++ b/update.sh
@@ -131,7 +131,7 @@ echo
 
 # Backup
 function fuBACKUP () {
-local myARCHIVE="/root/$(date +%Y%m%d%H%M)_tpot_backup.tgz"
+myARCHIVE="/root/$(date +%Y%m%d%H%M)_tpot_backup.tgz"
 local myPATH=$PWD
 echo "### Create a backup, just in case ... "
 echo -n "###### $myBLUE Building archive in $myARCHIVE $myWHITE"
@@ -258,6 +258,36 @@ echo "### Please reboot."
 echo
 }
 
+function fuRESTORE_HPFEED () {
+echo "### Restore HPFEED Settings in tpot.yml from backup"
+cd /tmp
+myEXTPATH=etc/compose/standard.yml
+tar -xzf $myARCHIVE $myEXTPATH
+
+if grep 'EWS_HPFEEDS_ENABLE=true' $myEXTPATH > /dev/null; then
+
+    myENABLE="true"
+    myHOST=$(grep EWS_HPFEEDS_HOST $myEXTPATH | cut -d= -f2)
+    myPORT=$(grep EWS_HPFEEDS_PORT $myEXTPATH | cut -d= -f2)
+    myCHANNEL=$(grep EWS_HPFEEDS_CHANNELS $myEXTPATH | cut -d= -f2)
+    myIDENT=$(grep EWS_HPFEEDS_IDENT $myEXTPATH | cut -d= -f2)
+    mySECRET=$(grep EWS_HPFEEDS_SECRET $myEXTPATH | cut -d= -f2)
+    myCERT=$( grep EWS_HPFEEDS_TLSCERT $myEXTPATH | cut -d= -f2)
+    myFORMAT=$(grep EWS_HPFEEDS_FORMAT $myEXTPATH | cut -d= -f2)
+
+    myTPOTYMLFILE="/opt/tpot/etc/tpot.yml"
+
+    sed --follow-symlinks -i "s/EWS_HPFEEDS_ENABLE.*/EWS_HPFEEDS_ENABLE=${myENABLE}/g" "$myTPOTYMLFILE"
+    sed --follow-symlinks -i "s/EWS_HPFEEDS_HOST.*/EWS_HPFEEDS_HOST=${myHOST}/g" "$myTPOTYMLFILE"
+    sed --follow-symlinks -i "s/EWS_HPFEEDS_PORT.*/EWS_HPFEEDS_PORT=${myPORT}/g" "$myTPOTYMLFILE"
+    sed --follow-symlinks -i "s/EWS_HPFEEDS_CHANNELS.*/EWS_HPFEEDS_CHANNELS=${myCHANNEL}/g" "$myTPOTYMLFILE"
+    sed --follow-symlinks -i "s/EWS_HPFEEDS_IDENT.*/EWS_HPFEEDS_IDENT=${myIDENT}/g" "$myTPOTYMLFILE"
+    sed --follow-symlinks -i "s/EWS_HPFEEDS_SECRET.*/EWS_HPFEEDS_SECRET=${mySECRET}/g" "$myTPOTYMLFILE"
+    sed --follow-symlinks -i "s#EWS_HPFEEDS_TLSCERT.*#EWS_HPFEEDS_TLSCERT=${myCERT}#g" "$myTPOTYMLFILE"
+    sed --follow-symlinks -i "s/EWS_HPFEEDS_FORMAT.*/EWS_HPFEEDS_FORMAT=${myFORMAT}/g" "$myTPOTYMLFILE"
+fi
+}
+
 
 ################
 # Main section #
@@ -289,3 +319,4 @@ fuSTOP_TPOT
 fuBACKUP
 fuSELFUPDATE "$0" "$@"
 fuUPDATER
+fuRESTORE_HPFEED

--- a/update.sh
+++ b/update.sh
@@ -288,6 +288,13 @@ if grep 'EWS_HPFEEDS_ENABLE=true' $myEXTPATH > /dev/null; then
 fi
 }
 
+function fuRESTORE_EWSCFG () {
+echo "### Restore volume mount for ews.cfg in tpot.yml if it existed before"
+if grep '/data/ews/conf/ews.cfg:/opt/ewsposter/ews.cfg' $myEXTPATH > /dev/null; then
+    sed -i '/\/opt\/ewsposter\/ews.ip/a\\ \ \ \ \ - /data/ews/conf/ews.cfg:/opt/ewsposter/ews.cfg' /opt/tpot/etc/tpot.yml
+fi
+}
+
 
 ################
 # Main section #
@@ -320,3 +327,4 @@ fuBACKUP
 fuSELFUPDATE "$0" "$@"
 fuUPDATER
 fuRESTORE_HPFEED
+fuRESTORE_EWSCFG


### PR DESCRIPTION
After executing the update.sh script, our custom settings in tpot.yml are overwritten.
Check in our backup whether the HPFEED settings or a custom ews.cfg volume mount were enabled before. If they were enabled, the old settings are extracted from the backup and reapplied to our new tpot.yml