### PR TITLE
Install sudo before apt-fast

### DIFF
--- a/iso/installer/install.sh
+++ b/iso/installer/install.sh
@@ -223,7 +223,7 @@ function fuCHECKPACKAGES {
     then
       echo "### Installing deps for apt-fast"
       apt-get -y update
-      apt-get -y install curl wget
+      apt-get -y install curl wget sudo
   fi
   echo "### Installing apt-fast"
   /bin/bash -c "$(curl -sL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)"

--- a/iso/installer/install.sh
+++ b/iso/installer/install.sh
@@ -219,7 +219,8 @@ function fuCHECKPACKAGES {
   # Make sure dependencies for apt-fast are installed
   myCURL=$(which curl)
   myWGET=$(which wget)
-  if [ "$myCURL" == "" ] || [ "$myWGET" == "" ]
+  mySUDO=$(which sudo)
+  if [ "$myCURL" == "" ] || [ "$myWGET" == "" ] || [ "$mySUDO" == "" ]
     then
       echo "### Installing deps for apt-fast"
       apt-get -y update


### PR DESCRIPTION
We need the sudo command to run the apt-fast installation script.
Debian doesn't come necessarily with the sudo command preinstalled.
Therefore the apt-fast installation fails.

- Added check whether sudo is installed
- Install sudo if needed