### PR TITLE
Fix AWS Terraform Deploy by switching to Debian Buster pre-release AMIs.

### DIFF
--- a/cloud/terraform/aws/main.tf
+++ b/cloud/terraform/aws/main.tf
@@ -62,4 +62,5 @@ resource "aws_instance" "tpot" {
   }
   user_data              = "${file("../cloud-init.yaml")}    content: ${base64encode(file("../tpot.conf"))}"
   vpc_security_group_ids = [aws_security_group.tpot.id]
+  associate_public_ip_address = true
 }

--- a/cloud/terraform/aws/variables.tf
+++ b/cloud/terraform/aws/variables.tf
@@ -28,26 +28,27 @@ variable "ec2_instance_type" {
   default = "t3.large"
 }
 
-# Refer to https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch
+# Refer to https://wiki.debian.org/Cloud/AmazonEC2Image/Buster
 variable "ec2_ami" {
   type = map(string)
   default = {
-    "ap-northeast-1" = "ami-09fbcd30452841cb9"
-    "ap-northeast-2" = "ami-08363ccce96df1fff"
-    "ap-south-1"     = "ami-0dc98cbb0d0e49162"
-    "ap-southeast-1" = "ami-0555b1a5444087dd4"
-    "ap-southeast-2" = "ami-029c54f988446691a"
-    "ca-central-1"   = "ami-04413a263a7d94982"
-    "eu-central-1"   = "ami-01fb3b7bab31acac5"
-    "eu-north-1"     = "ami-050f04ca573daa1fb"
-    "eu-west-1"      = "ami-0968f6a31fc6cffc0"
-    "eu-west-2"      = "ami-0faa9c9b5399088fd"
-    "eu-west-3"      = "ami-0cd23820af84edc85"
-    "sa-east-1"      = "ami-030580e61468e54bd"
-    "us-east-1"      = "ami-0357081a1383dc76b"
-    "us-east-2"      = "ami-09c10a66337c79669"
-    "us-west-1"      = "ami-0adbaf2e0ce044437"
-    "us-west-2"      = "ami-05a3ef6744aa96514"
+    "ap-east-1"      = "ami-b7d0abc6"
+    "ap-northeast-1" = "ami-01f4f0c9374675b99"
+    "ap-northeast-2" = "ami-0855cb0c55370c38c"
+    "ap-south-1"     = "ami-00d7d1cbdcb087cf3"
+    "ap-southeast-1" = "ami-03779b1b2fbb3a9d4"
+    "ap-southeast-2" = "ami-0ce3a7c68c6b1678d"
+    "ca-central-1"   = "ami-037099906a22f210f"
+    "eu-central-1"   = "ami-0845c3902a6f2af32"
+    "eu-north-1"     = "ami-e634bf98"
+    "eu-west-1"      = "ami-06a53bf81914447b5"
+    "eu-west-2"      = "ami-053d9f0770cd2e34c"
+    "eu-west-3"      = "ami-060bf1f444f742af9"
+    "me-south-1"     = "ami-04a9a536105c72d30"
+    "sa-east-1"      = "ami-0a5fd18ed0b9c7f35"
+    "us-east-1"      = "ami-01db78123b2b99496"
+    "us-east-2"      = "ami-010ffea14ff17ebf5"
+    "us-west-1"      = "ami-0ed1af421f2a3cf40"
+    "us-west-2"      = "ami-030a304a76b181155"
   }
 }
-


### PR DESCRIPTION
Fixes issue #455 by referencing the new Debian Buster AMIs that are not yet published to the marketplace. Confirmed this fixed the issue and auto-install now works. Also added associate_public_ip_address since that's required to access the instance remotely afterwards and to get honeypot traffic from the public Internet.