### PR TITLE
make Dockerfile compatible with any Python version

### DIFF
--- a/docker/cowrie/Dockerfile
+++ b/docker/cowrie/Dockerfile
@@ -36,9 +36,10 @@ RUN apk -U add \
     pip3 install --upgrade -r requirements.txt && \
 #
 # Setup configs
-    setcap cap_net_bind_service=+ep /usr/bin/python3.7 && \
+    export PYTHON_DIR=$(python3 --version | tr '[A-Z]' '[a-z]' | tr -d ' ' | cut -d '.' -f 1,2 ) && \
+    setcap cap_net_bind_service=+ep /usr/bin/$PYTHON_DIR && \
     cp /root/dist/cowrie.cfg /home/cowrie/cowrie/cowrie.cfg && \
-    chown cowrie:cowrie -R /home/cowrie/* /usr/lib/python3.7/site-packages/twisted/plugins && \
+    chown cowrie:cowrie -R /home/cowrie/* /usr/lib/$PYTHON_DIR/site-packages/twisted/plugins && \
 #
 # Start Cowrie once to prevent dropin.cache errors upon container start caused by read-only filesystem
     su - cowrie -c "export PYTHONPATH=/home/cowrie/cowrie:/home/cowrie/cowrie/src && \
@@ -59,7 +60,8 @@ RUN apk -U add \
                     py3-mysqlclient && \
     rm -rf /root/* /tmp/* && \
     rm -rf /var/cache/apk/* && \
-    rm -rf /home/cowrie/cowrie/cowrie.pid
+    rm -rf /home/cowrie/cowrie/cowrie.pid && \
+    unset PYTHON_DIR
 #
 # Start cowrie
 ENV PYTHONPATH /home/cowrie/cowrie:/home/cowrie/cowrie/src


### PR DESCRIPTION
adding a temporary variable to store the current (updated) version of Python, thus fixing the situation where the version is != 3.7 (e.g. Alpine python package at version 3.8.1-r1), causing lines 39-41 to break in the original code (install path is hard-coded at 3.7).