### PR TITLE
dynamically pin asyncssh and python versions

### DIFF
--- a/docker/heralding/Dockerfile
+++ b/docker/heralding/Dockerfile
@@ -23,16 +23,17 @@ RUN sed -i 's/dl-cdn/dl-2/g' /etc/apk/repositories && \
     cd /opt/ && \
     git clone --depth=1 https://github.com/johnnykv/heralding && \
     cd heralding && \
-    sed -i 's/asyncssh/asyncssh==1.18.0/' requirements.txt && \
+    sed -i 's/asyncssh\W*/asyncssh==/' requirements.txt && \
     pip3 install --no-cache-dir -r requirements.txt && \
     pip3 install --no-cache-dir . && \
 #
 # Setup user, groups and configs
+    export PYTHON_DIR=$(python3 --version | tr '[A-Z]' '[a-z]' | tr -d ' ' | cut -d '.' -f 1,2 ) && \
     addgroup -g 2000 heralding && \
     adduser -S -H -s /bin/ash -u 2000 -D -g 2000 heralding && \
     mkdir -p /var/log/heralding/ /etc/heralding && \
     mv /root/dist/heralding.yml /etc/heralding/ && \
-    setcap cap_net_bind_service=+ep /usr/bin/python3.7 && \
+    setcap cap_net_bind_service=+ep /usr/bin/$PYTHON_DIR && \
     chown -R heralding:heralding /var/log/heralding && \
 #
 # Clean up
@@ -47,7 +48,8 @@ RUN sed -i 's/dl-cdn/dl-2/g' /etc/apk/repositories && \
             py-virtualenv && \
     rm -rf /root/* \
            /var/cache/apk/* \
-           /opt/heralding
+           /opt/heralding && \
+    unset PYTHON_DIR
 #
 # Start Heralding
 STOPSIGNAL SIGINT


### PR DESCRIPTION
- version-pinning asyncssh dependency as defined in the upstream heralding requirements file (current sed command is accidentally concatenating the hard-coded string "1.18.0" with the version defined in the upstream heralding requirements file, resulting in a string like "asyncssh==1.18.0>=2.0.0". This will cause the Docker build to fail.
- dynamically setting python installation directory, making this Dockerfile compatible with any version of python (current path is hard-coded and the build might fail if a newer version of python - e.g. 3.8.1-r1 is installed)